### PR TITLE
Compute the financial goal always

### DIFF
--- a/app/Filament/Resources/AccountResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/AccountResource/RelationManagers/TransactionsRelationManager.php
@@ -103,7 +103,17 @@ class TransactionsRelationManager extends RelationManager
                     ->alignRight()
                     ->formatStateUsing(fn ($state) => as_money($state))
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->summarize([
+                        Tables\Columns\Summarizers\Sum::make('income')
+                            ->query(fn (\Illuminate\Database\Query\Builder $query) => $query->where('type', TransactionType::Income))
+                            ->formatStateUsing(fn ($state) => as_money($state))
+                            ->label('Ingresos'),
+                        Tables\Columns\Summarizers\Sum::make('outcome')
+                            ->query(fn (\Illuminate\Database\Query\Builder $query) => $query->where('type', TransactionType::Outcome))
+                            ->formatStateUsing(fn ($state) => as_money($state))
+                            ->label('Egresos'),
+                    ]),
                 Tables\Columns\TextColumn::make('type')
                     ->label('Tipo')
                     ->searchable()
@@ -124,6 +134,7 @@ class TransactionsRelationManager extends RelationManager
                     ->searchable(),
             ])
             ->groups([
+                Tables\Grouping\Group::make('scheduled_at')->label('Fecha'),
                 Tables\Grouping\Group::make('user.name')
                     ->label('Usuario'),
                 Tables\Grouping\Group::make('financialGoal.name')

--- a/app/Filament/Resources/AccountResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/AccountResource/RelationManagers/TransactionsRelationManager.php
@@ -22,6 +22,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Livewire\Component;
 
 class TransactionsRelationManager extends RelationManager
@@ -116,6 +117,17 @@ class TransactionsRelationManager extends RelationManager
                     ->label('Creado por')
                     ->sortable()
                     ->searchable(),
+                Tables\Columns\TextColumn::make('financialGoal.name')
+                    ->toggleable(isToggledHiddenByDefault: true)
+                    ->label('Meta financiera')
+                    ->sortable()
+                    ->searchable(),
+            ])
+            ->groups([
+                Tables\Grouping\Group::make('user.name')
+                    ->label('Usuario'),
+                Tables\Grouping\Group::make('financialGoal.name')
+                    ->label('Meta financiera'),
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('type')

--- a/app/Filament/Resources/TransactionResource.php
+++ b/app/Filament/Resources/TransactionResource.php
@@ -85,6 +85,7 @@ class TransactionResource extends Resource
             ->groups([
                 Tables\Grouping\Group::make('account.name')->label('Cuenta'),
                 Tables\Grouping\Group::make('scheduled_at')->label('Fecha'),
+                Tables\Grouping\Group::make('financialGoal.name')->label('Meta financiera'),
             ])
             ->columns([
                 Tables\Columns\TextColumn::make('concept')
@@ -123,6 +124,11 @@ class TransactionResource extends Resource
                 Tables\Columns\TextColumn::make('user.name')
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('financialGoal.name')
+                    ->toggleable(isToggledHiddenByDefault: true)
+                    ->label('Meta financiera')
+                    ->sortable()
+                    ->searchable(),
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('account_id')

--- a/app/Listeners/UpdateFinancialGoalsOnTransactionSaved.php
+++ b/app/Listeners/UpdateFinancialGoalsOnTransactionSaved.php
@@ -27,10 +27,6 @@ class UpdateFinancialGoalsOnTransactionSaved
      */
     public function handle(TransactionSaved $event): void
     {
-        if ($event->transaction->financial_goal_id === null) {
-            return;
-        }
-
         /** @var FinancialGoal $goal */
         $goal = $event->transaction->financialGoal;
 


### PR DESCRIPTION
## Changelog
- Compute the financial goal always to re-calculate after remove the relationship.
- Allow to group by financial goal.
- Allow to show financial goal in the relation manager.
- Allow to show financial goal in the transactions resource.
- Add summaries in transaction relation manager.